### PR TITLE
feat: add active users query tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MCP server for the [Cuti-E](https://cuti-e.com) admin API. Manage conversations,
 - Dashboard analytics (conversation stats, response times, breakdowns, trends)
 - Team member listing
 - Customer/team info
+- Active user stats (DAU/WAU/MAU) per app or across all apps
 
 ## Installation
 
@@ -74,6 +75,8 @@ Add to your `.mcp.json`:
 | `get_dashboard` | Analytics dashboard (stats, response times, trends) |
 | `list_team` | List team members and roles |
 | `get_customer` | Get team/customer info |
+| `get_active_users` | Get DAU/WAU/MAU for a specific app |
+| `get_active_users_all_apps` | Get active user counts across all apps |
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Add `get_active_users` tool to query DAU/WAU/MAU for a specific app via `/v1/activity/stats`
- Add `get_active_users_all_apps` tool to query active users across all apps (fetches app list then queries each in parallel)
- Update README with new tools

## Test plan

- [ ] Verify `get_active_users` returns correct stats for a known app_id with each period (24h, 7d, 30d)
- [ ] Verify `get_active_users_all_apps` returns stats array for all registered apps
- [ ] Verify error handling when app_id is invalid

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)